### PR TITLE
Bugfix release 3.2.1

### DIFF
--- a/assets/mod_info.json
+++ b/assets/mod_info.json
@@ -5,7 +5,7 @@
     "utility": true,
     "version": "3.2.1",
     "description": "A collection of intel boards for Starsector",
-    "gameVersion": "0.98a-RC5",
+    "gameVersion": "0.98a-RC7",
     "modPlugin": "stelnet.StelnetMod",
     "dependencies": [
         {

--- a/assets/mod_info.json
+++ b/assets/mod_info.json
@@ -3,7 +3,7 @@
     "name": "Stellar Networks",
     "author": "Jaghaimo",
     "utility": true,
-    "version": "3.2.0",
+    "version": "3.2.1",
     "description": "A collection of intel boards for Starsector",
     "gameVersion": "0.98a-RC5",
     "modPlugin": "stelnet.StelnetMod",

--- a/assets/stelnet.version
+++ b/assets/stelnet.version
@@ -5,8 +5,8 @@
     "modVersion": {
         "major": 3,
         "minor": 2,
-        "patch": 0
+        "patch": 1
     },
-    "directDownloadURL": "https://github.com/jaghaimo/stelnet/releases/download/3.2.0/stelnet-3.2.0.zip",
-    "changelogURL": "https://raw.githubusercontent.com/jaghaimo/stelnet/3.2.0/changelog.txt"
+    "directDownloadURL": "https://github.com/jaghaimo/stelnet/releases/download/3.2.1/stelnet-3.2.1.zip",
+    "changelogURL": "https://raw.githubusercontent.com/jaghaimo/stelnet/3.2.1/changelog.txt"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,7 @@ build {
 
 // compile time dependencies
 dependencies {
-    implementation "jaghaimo:starsector-api:0.98a-RC5@starfarer.api.jar"
+    implementation "jaghaimo:starsector-api:0.98a-RC7@starfarer.api.jar"
     zipped "Lukas22041:LunaLib:2.0.2@LunaLib.zip"
     implementation files({ tasks.installDependencies.extractedJars })
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 Version 3.2.1 (2025.04.04)
 - Fix market intel when using Group By Star System method.
+- Update the game dependency to 0.98a-RC7.
 
 
 Version 3.2.0 (2025.04.02)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+Version 3.2.1 (2025.04.04)
+- Fix market intel when using Group By Star System method.
+
+
 Version 3.2.0 (2025.04.02)
 - Update mod to Starsector 0.98a-RC5.
 

--- a/src/stelnet/board/IntelBasePlugin.java
+++ b/src/stelnet/board/IntelBasePlugin.java
@@ -28,7 +28,7 @@ public abstract class IntelBasePlugin extends RenderableIntel {
     }
 
     protected String getName() {
-        return sectorEntityToken.getMarket().getStarSystem().getName();
+        return StelnetHelper.getStarSystemName(sectorEntityToken.getStarSystem(), true);
     }
 
     @Override


### PR DESCRIPTION
```
Bugfix release 3.2.1

* Fix market intel when using Group By Star System method.
```
> java.lang.NullPointerException: Cannot invoke "com.fs.starfarer.api.campaign.econ.MarketAPI.getStarSystem()" because the return value of "com.fs.starfarer.api.campaign.SectorEntityToken.getMarket()" is null
