### PR TITLE
Bugfix for Intel window - duplicate tags (#118)

### DIFF
--- a/assets/data/config/tag_data.json
+++ b/assets/data/config/tag_data.json
@@ -1,17 +1,23 @@
 {
     "stelnetCommodity": {
         "name": "Commodities",
-        "putFirst": true,
-        "sort": 23
+        "color":[100,142,252,255],
+        #"width":150,
+        #"putFirst": true,
+        #"sort": 23
     },
     "stelnetMarket": {
         "name": "Markets",
-        "putFirst": true,
-        "sort": 24
+        "color":[100,142,252,255],
+        #"width":150,
+        #"putFirst": true,
+        #"sort": 24
     },
     "stelnetStorage": {
         "name": "Storage",
-        "putFirst": true,
-        "sort": 25
+        "color":[100,142,252,255],
+        #"width":150,
+        #"putFirst": true,
+        #"sort": 25
     }
 }

--- a/assets/mod_info.json
+++ b/assets/mod_info.json
@@ -3,7 +3,7 @@
     "name": "Stellar Networks",
     "author": "Jaghaimo",
     "utility": true,
-    "version": "3.2.1",
+    "version": "3.2.1-fix118",
     "description": "A collection of intel boards for Starsector",
     "gameVersion": "0.98a-RC7",
     "modPlugin": "stelnet.StelnetMod",

--- a/assets/mod_info.json
+++ b/assets/mod_info.json
@@ -3,7 +3,7 @@
     "name": "Stellar Networks",
     "author": "Jaghaimo",
     "utility": true,
-    "version": "3.2.1-fix118",
+    "version": "3.2.1",
     "description": "A collection of intel boards for Starsector",
     "gameVersion": "0.98a-RC7",
     "modPlugin": "stelnet.StelnetMod",

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,4 @@
-Version 3.2.1-fix118 (TBD)
+Version Unreleased (TBD)
 - Remove duplicate tags from Intel window (first row) and change font color (adjustable in `data/config/tag_data.json`).
 
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+Version 3.2.1-fix118 (TBD)
+- Remove duplicate tags from Intel window (first row) and change font color (adjustable in `data/config/tag_data.json`).
+
+
 Version 3.2.1 (2025.04.04)
 - Fix market intel when using Group By Star System method.
 - Update the game dependency to 0.98a-RC7.


### PR DESCRIPTION
Commit message:
```
Fix Intel window - duplicate tags (#118)

* Display Commodities, Markets and Storage tags in the second (alphabetical)
  row only, and change font color.
```
fixes #118 

Before change:
![Image](https://github.com/user-attachments/assets/f17d775a-bfe4-4040-b546-13b938c35cde)

After change:
![Screenshot from 2025-04-14 11-08-52](https://github.com/user-attachments/assets/f3ebd8d4-ae92-4808-a2fc-0b371d83ad32)

Optionally can comment out the font color in the `data/config/tag_data.json`:
![Screenshot from 2025-04-14 11-10-55](https://github.com/user-attachments/assets/4afe2370-806f-49c0-93c0-5bd3fdfc03a4)
