### PR TITLE
Fix market query results - submarket filters (#120)

### DIFF
--- a/assets/mod_info.json
+++ b/assets/mod_info.json
@@ -3,7 +3,7 @@
     "name": "Stellar Networks",
     "author": "Jaghaimo",
     "utility": true,
-    "version": "3.2.2",
+    "version": "3.2.1-dev",
     "description": "A collection of intel boards for Starsector",
     "gameVersion": "0.98a-RC7",
     "modPlugin": "stelnet.StelnetMod",

--- a/assets/mod_info.json
+++ b/assets/mod_info.json
@@ -3,7 +3,7 @@
     "name": "Stellar Networks",
     "author": "Jaghaimo",
     "utility": true,
-    "version": "3.2.1",
+    "version": "3.2.1-hf120",
     "description": "A collection of intel boards for Starsector",
     "gameVersion": "0.98a-RC7",
     "modPlugin": "stelnet.StelnetMod",

--- a/assets/stelnet.version
+++ b/assets/stelnet.version
@@ -5,7 +5,7 @@
     "modVersion": {
         "major": 3,
         "minor": 2,
-        "patch": 1-hf120
+        "patch": 1
     },
     "directDownloadURL": "https://github.com/jaghaimo/stelnet/releases/download/3.2.1/stelnet-3.2.1.zip",
     "changelogURL": "https://raw.githubusercontent.com/jaghaimo/stelnet/3.2.1/changelog.txt"

--- a/assets/stelnet.version
+++ b/assets/stelnet.version
@@ -5,7 +5,7 @@
     "modVersion": {
         "major": 3,
         "minor": 2,
-        "patch": 1
+        "patch": 1-hf120
     },
     "directDownloadURL": "https://github.com/jaghaimo/stelnet/releases/download/3.2.1/stelnet-3.2.1.zip",
     "changelogURL": "https://raw.githubusercontent.com/jaghaimo/stelnet/3.2.1/changelog.txt"

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
-Version 3.2.1-hf120 (TBD)
-- Hotfix for managing markets query results. Result intel entries will respect "Include Submarkets" now.
-  Market Viewer will respect the filter as well, probably shouldn't (need to look into this in a proper fix).
+Version Unreleased (TBD)
+- Fix for managing markets query results. Result intel entries will respect "Include Submarkets" now.
+  Market Viewer will respect the filter as well, consider changing this in the future.
 
 
 Version 3.2.1 (2025.04.04)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,8 @@
+Version 3.2.1-hf120 (TBD)
+- Hotfix for managing markets query results. Result intel entries will respect "Include Submarkets" now.
+  Market Viewer will respect the filter as well, probably shouldn't (need to look into this in a proper fix).
+
+
 Version 3.2.1 (2025.04.04)
 - Fix market intel when using Group By Star System method.
 - Update the game dependency to 0.98a-RC7.

--- a/src/stelnet/board/query/QueryManager.java
+++ b/src/stelnet/board/query/QueryManager.java
@@ -57,14 +57,14 @@ public class QueryManager {
     }
 
     public Set<Filter> getSubmarketFilters() {
-        if (Excluder.submarketFilters == null) {
-            Set<Filter> submarketFilters = new LinkedHashSet<>();
-            List<SubmarketSpecAPI> allSubmarketSpecs = getSubmarketSpecs();
-            for (SubmarketSpecAPI submarketSpec : allSubmarketSpecs) {
-                submarketFilters.add(getSubmarketFilter(submarketSpec));
-            }
-            Excluder.submarketFilters = submarketFilters;
+        if (Excluder.submarketFilters != null) return Excluder.submarketFilters;
+
+        Set<Filter> submarketFilters = new LinkedHashSet<>();
+        List<SubmarketSpecAPI> allSubmarketSpecs = getSubmarketSpecs();
+        for (SubmarketSpecAPI submarketSpec : allSubmarketSpecs) {
+            submarketFilters.add(getSubmarketFilter(submarketSpec));
         }
+        Excluder.submarketFilters = submarketFilters;
         return Excluder.submarketFilters;
     }
 

--- a/src/stelnet/board/query/QueryManager.java
+++ b/src/stelnet/board/query/QueryManager.java
@@ -57,12 +57,15 @@ public class QueryManager {
     }
 
     public Set<Filter> getSubmarketFilters() {
-        Set<Filter> submarketFilters = new LinkedHashSet<>();
-        List<SubmarketSpecAPI> allSubmarketSpecs = getSubmarketSpecs();
-        for (SubmarketSpecAPI submarketSpec : allSubmarketSpecs) {
-            submarketFilters.add(getSubmarketFilter(submarketSpec));
+        if (Excluder.submarketFilters == null) {
+            Set<Filter> submarketFilters = new LinkedHashSet<>();
+            List<SubmarketSpecAPI> allSubmarketSpecs = getSubmarketSpecs();
+            for (SubmarketSpecAPI submarketSpec : allSubmarketSpecs) {
+                submarketFilters.add(getSubmarketFilter(submarketSpec));
+            }
+            Excluder.submarketFilters = submarketFilters;
         }
-        return submarketFilters;
+        return Excluder.submarketFilters;
     }
 
     public Filter getSubmarketFilter(SubmarketSpecAPI submarketSpec) {

--- a/src/stelnet/board/query/QueryManager.java
+++ b/src/stelnet/board/query/QueryManager.java
@@ -64,8 +64,7 @@ public class QueryManager {
         for (SubmarketSpecAPI submarketSpec : allSubmarketSpecs) {
             submarketFilters.add(getSubmarketFilter(submarketSpec));
         }
-        Excluder.submarketFilters = submarketFilters;
-        return Excluder.submarketFilters;
+        return Excluder.submarketFilters = submarketFilters;
     }
 
     public Filter getSubmarketFilter(SubmarketSpecAPI submarketSpec) {

--- a/src/stelnet/filter/AnyHasId.java
+++ b/src/stelnet/filter/AnyHasId.java
@@ -14,6 +14,10 @@ public final class AnyHasId extends MarketFilter {
 
     private final String id;
 
+    public String toString() {
+        return id;
+    }
+
     @Override
     public boolean accept(Object object) {
         if (object instanceof SkillLevelAPI) {
@@ -36,19 +40,19 @@ public final class AnyHasId extends MarketFilter {
         return id.equalsIgnoreCase(market.getId());
     }
 
-    protected boolean acceptSkillLevel(SkillLevelAPI skillLevel) {
+    private boolean acceptSkillLevel(SkillLevelAPI skillLevel) {
         return acceptSkillSpec(skillLevel.getSkill());
     }
 
-    protected boolean acceptSkillSpec(SkillSpecAPI skillSpec) {
+    private boolean acceptSkillSpec(SkillSpecAPI skillSpec) {
         return id.equalsIgnoreCase(skillSpec.getId());
     }
 
-    protected boolean acceptSubmarket(SubmarketAPI submarket) {
+    private boolean acceptSubmarket(SubmarketAPI submarket) {
         return id.equalsIgnoreCase(submarket.getSpecId());
     }
 
-    protected boolean acceptSubmarketSpec(SubmarketSpecAPI submarketSpec) {
+    private boolean acceptSubmarketSpec(SubmarketSpecAPI submarketSpec) {
         return id.equalsIgnoreCase(submarketSpec.getId());
     }
 }

--- a/src/stelnet/filter/ResultHasId.java
+++ b/src/stelnet/filter/ResultHasId.java
@@ -14,6 +14,10 @@ public class ResultHasId extends ResultFilter {
         filter = new AnyHasId(id);
     }
 
+    public String toString() {
+        return "ResultHasId:" + filter;
+    }
+
     @Override
     protected boolean acceptResultSet(ResultSet resultSet) {
         return acceptResultSetCopy(resultSet);

--- a/src/stelnet/util/Excluder.java
+++ b/src/stelnet/util/Excluder.java
@@ -4,6 +4,8 @@ import com.fs.starfarer.api.impl.campaign.ids.Submarkets;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Set;
+
 import stelnet.filter.AnyHasId;
 import stelnet.filter.AnyHasTag;
 import stelnet.filter.Filter;
@@ -12,6 +14,7 @@ import stelnet.filter.LogicalNot;
 import stelnet.filter.LogicalOr;
 import stelnet.filter.MarketBelongsToFaction;
 import stelnet.filter.MarketIsInSystem;
+import stelnet.filter.ResultHasId;
 import stelnet.settings.BooleanSettings;
 
 /**
@@ -25,9 +28,10 @@ public class Excluder extends Reader {
     private static final String MARKET_BY_TAG = "data/stelnet/exclude/market_by_tag.csv";
     private static final String SKILL_BY_ID = "data/stelnet/exclude/skill_by_id.csv";
 
-    private static transient Filter marketFilter;
-    private static transient Filter skillFilter;
-    private static transient Filter submarketFilter;
+    private static Filter marketFilter;
+    private static Filter skillFilter;
+    private static Filter submarketFilter;
+    public static Set<Filter> submarketFilters;
 
     public static void resetCache() {
         marketFilter = null;
@@ -39,7 +43,8 @@ public class Excluder extends Reader {
         if (submarketFilter == null) {
             submarketFilter = getSubmarketFilters();
         }
-        return submarketFilter;
+        // Turn off caching for now.
+        return getSubmarketFilters();
     }
 
     public static Filter getMarketFilter() {
@@ -82,6 +87,9 @@ public class Excluder extends Reader {
             filters.add(
                 new LogicalNot(new LogicalOr(Arrays.asList(storage, openMarket, militaryMarket, blackMarket), "Custom"))
             );
+        }
+        if (submarketFilters != null) {
+            filters.removeIf(filter -> !submarketFilters.contains(new ResultHasId(filter.toString())));
         }
         return new LogicalAnd(Arrays.asList(new LogicalNot(storage), new LogicalOr(filters, "Submarkets")));
     }

--- a/src/stelnet/util/Excluder.java
+++ b/src/stelnet/util/Excluder.java
@@ -43,7 +43,7 @@ public class Excluder extends Reader {
         if (submarketFilter == null) {
             submarketFilter = getSubmarketFilters();
         }
-        // Turn off caching for now.
+        // Turn off caching for now (https://github.com/jaghaimo/stelnet/issues/120).
         return getSubmarketFilters();
     }
 


### PR DESCRIPTION
Commit message:
```
Fix market query results - submarket filters (#120)

* Implement `toString` for easier debug/logging.
* Address code analysis warnings:
  - Class member declared 'protected' in 'final' class;
  - Modifier 'transient' is redundant for a 'static' field;
* Turn off caching of submarkets and introduce additional set to minimise changes.
```
Mitigates #120 
