### PR TITLE
Fix custom contacts wiping out player's fleet (#119)

### DIFF
--- a/assets/mod_info.json
+++ b/assets/mod_info.json
@@ -3,7 +3,7 @@
     "name": "Stellar Networks",
     "author": "Jaghaimo",
     "utility": true,
-    "version": "3.2.1",
+    "version": "3.2.1-hf119",
     "description": "A collection of intel boards for Starsector",
     "gameVersion": "0.98a-RC7",
     "modPlugin": "stelnet.StelnetMod",

--- a/assets/stelnet.version
+++ b/assets/stelnet.version
@@ -5,7 +5,7 @@
     "modVersion": {
         "major": 3,
         "minor": 2,
-        "patch": 1-hf119
+        "patch": 1
     },
     "directDownloadURL": "https://github.com/jaghaimo/stelnet/releases/download/3.2.1/stelnet-3.2.1.zip",
     "changelogURL": "https://raw.githubusercontent.com/jaghaimo/stelnet/3.2.1/changelog.txt"

--- a/assets/stelnet.version
+++ b/assets/stelnet.version
@@ -5,7 +5,7 @@
     "modVersion": {
         "major": 3,
         "minor": 2,
-        "patch": 1
+        "patch": 1-hf119
     },
     "directDownloadURL": "https://github.com/jaghaimo/stelnet/releases/download/3.2.1/stelnet-3.2.1.zip",
     "changelogURL": "https://raw.githubusercontent.com/jaghaimo/stelnet/3.2.1/changelog.txt"

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,5 @@
-Version 3.2.1-hf119 (TBD)
-- Hotfix for modded contacts that wipe out player's fleet when calling them remotely while they do not want to talk with the player.
+Version Unreleased (TBD)
+- Fix for modded contacts that can wipe out player's fleet when calling them remotely while they do not want to talk with the player.
   Instead, a dialog window will be displayed that will disappear immediately.
 
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,8 @@
+Version 3.2.1-hf119 (TBD)
+- Hotfix for modded contacts that wipe out player's fleet when calling them remotely while they do not want to talk with the player.
+  Instead, a dialog window will be displayed that will disappear immediately.
+
+
 Version 3.2.1 (2025.04.04)
 - Fix market intel when using Group By Star System method.
 - Update the game dependency to 0.98a-RC7.

--- a/src/stelnet/board/contact/ContactDialog.java
+++ b/src/stelnet/board/contact/ContactDialog.java
@@ -37,8 +37,8 @@ public class ContactDialog extends RuleBasedInteractionDialogPluginImpl {
     public void init(InteractionDialogAPI dialog) {
         SectorEntityToken token = dialog.getInteractionTarget();
         token.setActivePerson(person);
-        super.init(dialog);
         this.dialog = dialog;
+        super.init(dialog);
     }
 
     @Override

--- a/src/stelnet/board/contact/ContactDialog.java
+++ b/src/stelnet/board/contact/ContactDialog.java
@@ -8,13 +8,16 @@ import com.fs.starfarer.api.campaign.econ.SubmarketAPI;
 import com.fs.starfarer.api.characters.PersonAPI;
 import com.fs.starfarer.api.impl.campaign.RuleBasedInteractionDialogPluginImpl;
 import com.fs.starfarer.api.ui.IntelUIAPI;
+import lombok.extern.log4j.Log4j;
 import stelnet.util.MemoryHelper;
 import stelnet.util.ModConstants;
 import stelnet.util.StelnetHelper;
 
+@Log4j
 public class ContactDialog extends RuleBasedInteractionDialogPluginImpl {
 
     private InteractionDialogAPI dialog;
+    private InteractionDialogAPI dialog2;
     private final MarketAPI market;
     private final PersonAPI person;
     private final IntelUIAPI ui;
@@ -37,13 +40,19 @@ public class ContactDialog extends RuleBasedInteractionDialogPluginImpl {
     public void init(InteractionDialogAPI dialog) {
         SectorEntityToken token = dialog.getInteractionTarget();
         token.setActivePerson(person);
-        this.dialog = dialog;
+        this.dialog2 = dialog;  // Use another variable to log when problem happens.
         super.init(dialog);
+        this.dialog = dialog;
     }
 
     @Override
     public void notifyActivePersonChanged() {
-        dialog.hideVisualPanel();
+        if (dialog != null) {
+            dialog.hideVisualPanel();
+        } else {
+            log.warn("Dialog is not set, fallback and call dialog2.hideVisualPanel. For more info see GH issue #119.");
+            //dialog2.hideVisualPanel();  // not needed?
+        }
         super.notifyActivePersonChanged();
         dismiss();
     }
@@ -81,7 +90,12 @@ public class ContactDialog extends RuleBasedInteractionDialogPluginImpl {
             storageData.add(playerData);
             playerData.restore();
         }
-        dialog.dismiss();
+        if (this.dialog != null) {
+            dialog.dismiss();
+        } else {
+            log.warn("Dialog is not set, fallback and call dialog2.dismiss. For more info see GH issue #119.");
+            dialog2.dismiss();
+        }
         ui.recreateIntelUI();
         ui.updateUIForItem(board);
     }


### PR DESCRIPTION
Commit message:
```
Fix custom contacts wiping out player's fleet (#119)

* Instead of wiping out player's fleet, it will show and instantly hide contact's dialog window.
* Log when the problem happens.
```
Mitigates #119 